### PR TITLE
Refactor: Resolve minor broken tests post merge conflict

### DIFF
--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -3,20 +3,13 @@ require './lib/player'
 require './lib/turn'
 
 RSpec.describe Turn do
-  let(:player1) { Player.new('George', 'X') }
-  let(:player2) {Player.new('Hal', 'O')}
+  let(:player) { Player.new('George', 'X') }
+  let(:computer) {Player.new('Hal', 'O')}
   let(:board) {Board.new}
-  let(:turn) {Turn.new(board,player1,player2)}
-  let(:game) { Turn.new(board, player, computer)}
+  let(:turn) {Turn.new(board,player,computer)}
 
   it 'should be an instance of a Turn class'do
     expect(turn).to be_a Turn
-  end
-  
-  it "has a method for the computer move" do
-    game.computer_move
-    board.invert_board
-    expect(game.board.horizontal_board[0].join).to eq('O')
   end
 
   it 'should recieve a single input from players'do
@@ -51,19 +44,25 @@ RSpec.describe Turn do
     expect(turn.valid_input_character(letter)).to eq true
   end
 
+  it "has a method for the computer move" do
+    turn.computer_move
+    board.invert_board
+    expect(turn.board.horizontal_board[0].join).to eq('O')
+  end
+  
   it "has a method to check if a column is full" do
     board.game_board['A'].push(computer.chip)
     board.game_board['A'].push(computer.chip)
     board.game_board['A'].push(computer.chip)
     board.game_board['A'].push(computer.chip)
     board.game_board['A'].push(computer.chip)
-    expect(game.column_full?('A')).to eq(false)
+    expect(turn.column_full?('A')).to eq(false)
     board.game_board['A'].push(computer.chip)
-    expect(game.column_full?('A')).to eq(true)
+    expect(turn.column_full?('A')).to eq(true)
   end
   
   it "has a method to check if all columns are full" do
-    expect(game.draw?).to eq(false)
+    expect(turn.draw?).to eq(false)
     6.times do
       board.game_board['A'].push(computer.chip)
       board.game_board['B'].push(computer.chip)
@@ -73,6 +72,6 @@ RSpec.describe Turn do
       board.game_board['F'].push(computer.chip)
       board.game_board['G'].push(computer.chip)
     end
-    expect(game.draw?).to eq(true)
+    expect(turn.draw?).to eq(true)
   end
 end


### PR DESCRIPTION
Minor differences in the names of object instances used in the turn_spec was causing some of the tests to fail after merging PR#8 . This commit resolves those conflicts.